### PR TITLE
Add pybind11 bindings and CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.18)
+project(SPH LANGUAGES CXX)
+
+option(USE_CUDA "Build with CUDA support" ON)
+
+if(USE_CUDA)
+    enable_language(CUDA)
+    add_compile_definitions(USE_CUDA)
+endif()
+
+add_library(sph STATIC src/sph/core/world.cpp)
+target_include_directories(sph PUBLIC src)
+
+if(USE_CUDA)
+    set_source_files_properties(src/sph/core/world.cpp PROPERTIES LANGUAGE CUDA)
+endif()
+
+add_subdirectory(bindings)

--- a/README.md
+++ b/README.md
@@ -1,31 +1,43 @@
 # SPH
 
-This repository contains a Windows example project implementing a simple
-Smoothed Particle Hydrodynamics (SPH) simulation.
+This repository contains a simple Smoothed Particle Hydrodynamics (SPH) simulation.
 
-## Building the library
+## Building the library (Visual Studio)
 
-The project is distributed as a Visual Studio solution.  Open
+The original project is distributed as a Visual Studio solution.  Open
 `WindowsProject_optimization_SPH.sln` with Visual Studio 2022 (or newer)
 and build either the `Debug` or `Release` configuration for `x64`.
 The resulting binaries are written to `x64/Debug` or `x64/Release`.
 
-## Building the Python module
+## Building with CMake
 
-Python bindings can be built with `pybind11`.  After installing
-`pybind11` and a working C++ toolchain run the following command in the
-repository root:
+The library and Python bindings can also be built using CMake.  On both
+Linux and Windows the typical workflow is:
 
 ```console
-python setup.py build_ext --inplace
+mkdir build
+cd build
+cmake -DUSE_CUDA=OFF ..   # set to ON when the CUDA toolkit is available
+cmake --build . --target _sph
 ```
 
-This will create a `sph` module that can be imported from Python.
+This will produce a Python extension named `_sph` inside the build
+directory.
+
+## Using the Python module
+
+The bindings expose a `PyWorld` class:
+
+```python
+from _sph import PyWorld
+w = PyWorld()
+w.step(1/60.0)
+positions = w.get_positions()
+```
 
 ## Running the example GUI
 
-After building the solution an executable named
+After building the Visual Studio solution an executable named
 `WindowsProject_optimization_SPH.exe` will be produced inside the build
 output directory.  Launching this executable starts the example GUI
 showing the SPH simulation.
-

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,0 +1,10 @@
+find_package(pybind11 REQUIRED)
+
+pybind11_add_module(_sph pybind_module.cpp)
+
+target_link_libraries(_sph PRIVATE sph)
+
+if(USE_CUDA)
+    set_target_properties(_sph PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
+endif()
+

--- a/bindings/pybind_module.cpp
+++ b/bindings/pybind_module.cpp
@@ -1,0 +1,33 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include "sph/core/world.h"
+
+namespace py = pybind11;
+
+class PyWorld {
+public:
+    PyWorld() = default;
+
+    void step(float dt) { world.update(dt); }
+
+    py::array_t<float> get_positions() const {
+        constexpr int N = sph::World::numParticle;
+        const float (*pos)[2] = world.getPositions();
+        return py::array_t<float>({N, 2}, &pos[0][0]);
+    }
+
+    float width() const { return world.getWorldWidth(); }
+    float height() const { return world.getWorldHeight(); }
+
+private:
+    sph::World world;
+};
+
+PYBIND11_MODULE(_sph, m) {
+    py::class_<PyWorld>(m, "PyWorld")
+        .def(py::init<>())
+        .def("step", &PyWorld::step, py::arg("dt"))
+        .def("get_positions", &PyWorld::get_positions)
+        .def_property_readonly("width", &PyWorld::width)
+        .def_property_readonly("height", &PyWorld::height);
+}


### PR DESCRIPTION
## Summary
- expose a `PyWorld` wrapper through pybind11
- add CMake build files for the C++ library and bindings
- document building the module with CMake

## Testing
- `cmake -S . -B build -DUSE_CUDA=OFF` *(fails: Could not find pybind11)*

------
https://chatgpt.com/codex/tasks/task_e_685d6317db108324a529f711c7a69b4b