### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,14 @@ The resulting binaries are written to `x64/Debug` or `x64/Release`.
 
 ## Building with CMake
 
-The library and Python bindings can also be built using CMake.  On both
-Linux and Windows the typical workflow is:
+The library and Python bindings can also be built using CMake.  Before
+invoking CMake run the setup script in the repository root:
+
+```console
+./setup.sh
+```
+
+After the script completes you can use the usual workflow:
 
 ```console
 mkdir build

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+# Install required Python packages
+python3 -m pip install --user pybind11
+
+# Create build directory and build the Python extension
+mkdir -p build
+cd build
+cmake -DUSE_CUDA=OFF ..   # set to ON when the CUDA toolkit is available
+cmake --build . --target _sph


### PR DESCRIPTION
## Summary
- add `setup.sh` to install pybind11 and build the project
- document running the setup script before normal CMake steps

## Testing
- `python3 -m pip install --user pybind11`
- `cmake --version`

------
https://chatgpt.com/codex/tasks/task_e_685d6a1e055c83249360e17e5633b09a