### PR TITLE
Add tests and integrate with pytest/ctest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.18)
 project(SPH LANGUAGES CXX)
 
+enable_testing()
+
 option(USE_CUDA "Build with CUDA support" ON)
 
 if(USE_CUDA)
@@ -9,6 +11,7 @@ if(USE_CUDA)
 endif()
 
 add_library(sph STATIC src/sph/core/world.cpp)
+set_target_properties(sph PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(sph PUBLIC src)
 
 if(USE_CUDA)
@@ -16,3 +19,4 @@ if(USE_CUDA)
 endif()
 
 add_subdirectory(bindings)
+add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+add_executable(test_calc test_calc.cpp)
+target_link_libraries(test_calc PRIVATE sph)
+add_test(NAME cpp_test_calc COMMAND test_calc)
+
+add_executable(test_kernel_compare test_kernel_compare.cpp)
+target_link_libraries(test_kernel_compare PRIVATE sph)
+add_test(NAME cpp_test_kernel_compare COMMAND test_kernel_compare)
+
+add_test(NAME python_tests
+          COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}
+)
+set_tests_properties(python_tests PROPERTIES
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}"
+)

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1,0 +1,21 @@
+import numpy as np
+import _sph
+
+
+def test_world_properties():
+    w = _sph.PyWorld()
+    assert w.width() > 0
+    assert w.height() > 0
+    pos = w.get_positions()
+    assert pos.ndim == 2
+    assert pos.shape[1] == 2
+    assert pos.shape[0] > 0
+
+
+def test_step_updates_positions():
+    w = _sph.PyWorld()
+    before = w.get_positions().copy()
+    w.step(1.0 / 60.0)
+    after = w.get_positions()
+    assert after.shape == before.shape
+    assert np.any(before != after)

--- a/tests/test_kernel_compare.cpp
+++ b/tests/test_kernel_compare.cpp
@@ -1,0 +1,23 @@
+#include <cassert>
+#include <cmath>
+#include <vector>
+#include "sph/core/kernels.h"
+#include "sph/core/kernels_cuda.h"
+
+int main() {
+    const float radius = 1.5f;
+    std::vector<float> distances;
+    for (int i = 0; i <= 20; ++i) {
+        distances.push_back(radius * i / 20.0f);
+    }
+    const int n = static_cast<int>(distances.size());
+    std::vector<float> cpu(n), gpu(n);
+    for (int i = 0; i < n; ++i) {
+        cpu[i] = sph::calcSmoothingKernel(distances[i], radius);
+    }
+    sph::calcSmoothingKernelCUDA(distances.data(), gpu.data(), radius, n);
+    for (int i = 0; i < n; ++i) {
+        assert(std::abs(cpu[i] - gpu[i]) < 1e-5f);
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- enable testing with CMake
- build sph as position independent code
- add cpp tests and integrate pytest
- add Python unit tests to exercise the bindings

## Testing
- `cmake -DUSE_CUDA=OFF -Dpybind11_DIR=\`python3 -m pybind11 --cmakedir\` ..`
- `cmake --build .`
- `ctest --output-on-failure` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685d6ef530ec8324a79cbd477b4c6c19