### PR TITLE
Enable C++20 and fix CUDA build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,32 @@
 cmake_minimum_required(VERSION 3.18)
 project(SPH LANGUAGES CXX)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 enable_testing()
 
 option(USE_CUDA "Build with CUDA support" ON)
 
 if(USE_CUDA)
     enable_language(CUDA)
+    set(CMAKE_CUDA_STANDARD 20)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
     add_compile_definitions(USE_CUDA)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
 endif()
 
-add_library(sph STATIC src/sph/core/world.cpp)
+set(SPH_SOURCES src/sph/core/world.cpp)
+if(USE_CUDA)
+    list(APPEND SPH_SOURCES src/sph/core/kernels_cuda.cu)
+endif()
+add_library(sph STATIC ${SPH_SOURCES})
 set_target_properties(sph PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_include_directories(sph PUBLIC src)
 find_package(TBB REQUIRED)
 target_link_libraries(sph PUBLIC TBB::tbb)
 
-if(USE_CUDA)
-    set_source_files_properties(src/sph/core/world.cpp PROPERTIES LANGUAGE CUDA)
-endif()
+
 
 add_subdirectory(bindings)
 add_subdirectory(tests)

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -4,6 +4,16 @@ pybind11_add_module(_sph pybind_module.cpp)
 
 target_link_libraries(_sph PRIVATE sph)
 
+set_target_properties(_sph PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}
+)
+
+if(USE_CUDA)
+    set_target_properties(_sph PROPERTIES
+        INTERPROCEDURAL_OPTIMIZATION OFF
+    )
+endif()
+
 if(USE_CUDA)
     set_target_properties(_sph PROPERTIES CUDA_SEPARABLE_COMPILATION ON)
 endif()

--- a/src/sph/core/kernels_cuda.cu
+++ b/src/sph/core/kernels_cuda.cu
@@ -1,0 +1,44 @@
+#include "kernels_cuda.h"
+
+#ifdef USE_CUDA
+
+namespace sph {
+
+__global__ void calcSmoothingKernelKernel(const float* dist, float* out, float radius, int n)
+{
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        float d = dist[idx];
+        float val = 0.0f;
+        if (d < radius) {
+            float volume = (float)(M_PI * radius * radius * radius * radius) / 6.0f;
+            float t = radius - d;
+            val = t * t / volume;
+        }
+        out[idx] = val;
+    }
+}
+
+void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n)
+{
+    float* d_in = nullptr;
+    float* d_out = nullptr;
+    CUDA_CHECK(cudaMalloc(&d_in, n * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&d_out, n * sizeof(float)));
+    CUDA_CHECK(cudaMemcpy(d_in, dist, n * sizeof(float), cudaMemcpyHostToDevice));
+
+    int threads = 256;
+    int blocks = (n + threads - 1) / threads;
+    calcSmoothingKernelKernel<<<blocks, threads>>>(d_in, d_out, radius, n);
+    CUDA_KERNEL_CHECK();
+    CUDA_CHECK(cudaDeviceSynchronize());
+
+    CUDA_CHECK(cudaMemcpy(out, d_out, n * sizeof(float), cudaMemcpyDeviceToHost));
+
+    CUDA_CHECK(cudaFree(d_in));
+    CUDA_CHECK(cudaFree(d_out));
+}
+
+} // namespace sph
+
+#endif // USE_CUDA

--- a/src/sph/core/kernels_cuda.h
+++ b/src/sph/core/kernels_cuda.h
@@ -10,44 +10,18 @@
 #endif
 
 namespace sph {
+
 #ifdef USE_CUDA
 
-__global__ void calcSmoothingKernelKernel(const float* dist, float* out, float radius, int n)
-{
-    int idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx < n) {
-        float d = dist[idx];
-        float val = 0.0f;
-        if (d < radius) {
-            float volume = (float)(M_PI * radius * radius * radius * radius) / 6.0f;
-            float t = radius - d;
-            val = t * t / volume;
-        }
-        out[idx] = val;
-    }
-}
+// CUDA implementation of the smoothing kernel lives in a separate translation
+// unit. When compiling this header with a host compiler (i.e. when __CUDACC__ is
+// not defined) only the declarations are visible.
+#ifdef __CUDACC__
+__global__ void calcSmoothingKernelKernel(const float* dist, float* out, float radius, int n);
+#endif
+void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n);
 
-inline void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n)
-{
-    float* d_in = nullptr;
-    float* d_out = nullptr;
-    CUDA_CHECK(cudaMalloc(&d_in, n * sizeof(float)));
-    CUDA_CHECK(cudaMalloc(&d_out, n * sizeof(float)));
-    CUDA_CHECK(cudaMemcpy(d_in, dist, n * sizeof(float), cudaMemcpyHostToDevice));
-
-    int threads = 256;
-    int blocks = (n + threads - 1) / threads;
-    calcSmoothingKernelKernel<<<blocks, threads>>>(d_in, d_out, radius, n);
-    CUDA_KERNEL_CHECK();
-    CUDA_CHECK(cudaDeviceSynchronize());
-
-    CUDA_CHECK(cudaMemcpy(out, d_out, n * sizeof(float), cudaMemcpyDeviceToHost));
-
-    CUDA_CHECK(cudaFree(d_in));
-    CUDA_CHECK(cudaFree(d_out));
-}
-
-#else
+#else // !USE_CUDA
 
 inline void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n)
 {


### PR DESCRIPTION
## Summary
- build with C++20
- split CUDA kernels into a .cu file so the host code can be compiled normally
- place python module output in build directory and disable LTO when using CUDA

## Testing
- `cmake -DUSE_CUDA=ON -Dpybind11_DIR=$(python3 -c "import pybind11, os; print(pybind11.get_cmake_dir())") .. && cmake --build .` *(fails: no CUDA-capable device)*
- `ctest --output-on-failure` *(fails: no CUDA-capable device)*
- `cmake -DUSE_CUDA=OFF -Dpybind11_DIR=$(python3 -c "import pybind11, os; print(pybind11.get_cmake_dir())") .. && cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_685ded1d23cc8324a6102946ccc415fa