### PR TITLE
Add interactive forces to Pygame demo

### DIFF
--- a/bindings/pybind_module.cpp
+++ b/bindings/pybind_module.cpp
@@ -25,6 +25,12 @@ public:
     float width() const { return world.getWorldWidth(); }
     float height() const { return world.getWorldHeight(); }
 
+    void set_interaction_force(float x, float y, float radius, float strength) {
+        world.setInteractionForce(x, y, radius, strength);
+    }
+
+    void delete_interaction_force() { world.deleteInteractionForce(); }
+
 private:
     sph::World world;
 };
@@ -36,5 +42,13 @@ PYBIND11_MODULE(_sph, m) {
         .def("get_positions", &PyWorld::get_positions)
         .def("get_velocities", &PyWorld::get_velocities)
         .def("width", &PyWorld::width)
-        .def("height", &PyWorld::height);
+        .def("height", &PyWorld::height)
+        .def(
+            "set_interaction_force",
+            &PyWorld::set_interaction_force,
+            py::arg("x"),
+            py::arg("y"),
+            py::arg("radius"),
+            py::arg("strength"))
+        .def("delete_interaction_force", &PyWorld::delete_interaction_force);
 }

--- a/examples/run_gui.py
+++ b/examples/run_gui.py
@@ -14,10 +14,23 @@ def main():
 
     dt = 1 / 60.0
     running = True
+    force_radius = 2.0
+    force_strength = 10.0
+
     while running:
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
+        
+        left, middle, right = pygame.mouse.get_pressed(num_buttons=3)
+        if left or right:
+            x, y = pygame.mouse.get_pos()
+            world_x = x / scale
+            world_y = y / scale
+            strength = force_strength if left else -force_strength
+            world.set_interaction_force(world_x, world_y, force_radius, strength)
+        else:
+            world.delete_interaction_force()
 
         world.step(dt)
         positions = world.get_positions()
@@ -27,7 +40,7 @@ def main():
             pygame.draw.circle(
                 screen,
                 (255, 255, 255),
-                (int(x * scale), int(height - y * scale)),
+                (int(x * scale), int(y * scale)),
                 2,
             )
         pygame.display.flip()

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -19,3 +19,11 @@ def test_step_updates_positions():
     after = w.get_positions()
     assert after.shape == before.shape
     assert np.any(before != after)
+
+
+def test_interaction_force_methods():
+    w = _sph.PyWorld()
+    # set an interaction force and step the simulation; just ensure no errors
+    w.set_interaction_force(1.0, 1.0, 2.0, 5.0)
+    w.step(1.0 / 60.0)
+    w.delete_interaction_force()


### PR DESCRIPTION
## Summary
- fix particle rendering so y axis matches the simulation
- allow interactive forces in the Pygame demo using mouse buttons
- expose set/delete interaction force methods in PyWorld
- add tests for interaction force bindings

## Testing
- `cmake -DUSE_CUDA=OFF -Dpybind11_DIR=$(python3 - <<'PY'
import pybind11
print(pybind11.get_cmake_dir())
PY
) ..`
- `cmake --build . --target _sph`
- `PYTHONPATH=build pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dfe37406c8324938458e7056c8614