### PR TITLE
Display FPS and processing time

### DIFF
--- a/examples/run_gui.py
+++ b/examples/run_gui.py
@@ -1,3 +1,4 @@
+import time
 import pygame
 from _sph import PyWorld
 
@@ -11,6 +12,7 @@ def main():
     pygame.init()
     screen = pygame.display.set_mode((width, height))
     clock = pygame.time.Clock()
+    font = pygame.font.SysFont(None, 24)
 
     dt = 1 / 60.0
     running = True
@@ -18,6 +20,7 @@ def main():
     force_strength = 10.0
 
     while running:
+        start_time = time.perf_counter()
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
@@ -34,6 +37,7 @@ def main():
 
         world.step(dt)
         positions = world.get_positions()
+        proc_time = (time.perf_counter() - start_time) * 1000.0
 
         screen.fill((0, 0, 0))
         for x, y in positions:
@@ -43,6 +47,9 @@ def main():
                 (int(x * scale), int(y * scale)),
                 2,
             )
+        text = f"FPS: {clock.get_fps():.2f} | Time: {proc_time:.2f} ms"
+        img = font.render(text, True, (255, 0, 0))
+        screen.blit(img, (10, 10))
         pygame.display.flip()
         clock.tick(60)
 


### PR DESCRIPTION
## Summary
- add FPS and frame processing time overlay to the example GUI

## Testing
- `./setup.sh` *(fails: Could not find pybind11)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named '_sph')*

------
https://chatgpt.com/codex/tasks/task_e_685e0552971483248165f9fa2b22d3e1