### PR TITLE
Add configurable simulation parameters

### DIFF
--- a/bindings/pybind_module.cpp
+++ b/bindings/pybind_module.cpp
@@ -6,7 +6,19 @@ namespace py = pybind11;
 
 class PyWorld {
 public:
-    PyWorld() = default;
+    PyWorld(
+        float width = 20.0f,
+        float height = 10.0f,
+        float smoothing_radius = 0.8f,
+        float target_density = 32.0f,
+        float pressure_multiplier = 100.0f,
+        float drag = 0.9999f,
+        float gravity = 9.8f,
+        float collision_damping = 1.0f,
+        float delta = 0.0f)
+        : world(sph::WorldConfig{width, height, smoothing_radius, target_density,
+                               pressure_multiplier, delta, drag, gravity,
+                               collision_damping}) {}
 
     void step(float dt) { world.update(dt); }
 
@@ -24,6 +36,9 @@ public:
 
     float width() const { return world.getWorldWidth(); }
     float height() const { return world.getWorldHeight(); }
+    float smoothing_radius() const { return world.getSmoothingRadius(); }
+    float gravity() const { return world.getGravity(); }
+    float drag() const { return world.getDrag(); }
 
     void set_interaction_force(float x, float y, float radius, float strength) {
         world.setInteractionForce(x, y, radius, strength);
@@ -37,12 +52,34 @@ private:
 
 PYBIND11_MODULE(_sph, m) {
     py::class_<PyWorld>(m, "PyWorld")
-        .def(py::init<>())
+        .def(
+            py::init<
+                float,
+                float,
+                float,
+                float,
+                float,
+                float,
+                float,
+                float,
+                float>(),
+            py::arg("width") = 20.0f,
+            py::arg("height") = 10.0f,
+            py::arg("smoothing_radius") = 0.8f,
+            py::arg("target_density") = 32.0f,
+            py::arg("pressure_multiplier") = 100.0f,
+            py::arg("drag") = 0.9999f,
+            py::arg("gravity") = 9.8f,
+            py::arg("collision_damping") = 1.0f,
+            py::arg("delta") = 0.0f)
         .def("step", &PyWorld::step, py::arg("dt"))
         .def("get_positions", &PyWorld::get_positions)
         .def("get_velocities", &PyWorld::get_velocities)
         .def("width", &PyWorld::width)
         .def("height", &PyWorld::height)
+        .def("smoothing_radius", &PyWorld::smoothing_radius)
+        .def("gravity", &PyWorld::gravity)
+        .def("drag", &PyWorld::drag)
         .def(
             "set_interaction_force",
             &PyWorld::set_interaction_force,

--- a/src/sph/core/world.cpp
+++ b/src/sph/core/world.cpp
@@ -55,7 +55,18 @@ std::vector<int> GridMap::findNeighborhood(float x, float y, float radius) {
     return out;
 }
 
-World::World() : forcePoint{{0,0},0,0}, gridmap(worldSize[0], worldSize[1], smoothingRadius) {
+World::World(const WorldConfig& config)
+    : gravity(config.gravity),
+      worldSize{config.worldWidth, config.worldHeight},
+      collisionDamping(config.collisionDamping),
+      smoothingRadius(config.smoothingRadius),
+      targetDensity(config.targetDensity),
+      pressureMultiplier(config.pressureMultiplier),
+      delta(config.delta),
+      drag(config.drag),
+      forcePoint{{0,0},0,0},
+      gridmap(worldSize[0], worldSize[1], smoothingRadius)
+{
     std::memset(pos, 0, sizeof(pos));
     std::memset(predpos, 0, sizeof(predpos));
     std::memset(vel, 0, sizeof(vel));

--- a/src/sph/core/world.h
+++ b/src/sph/core/world.h
@@ -40,20 +40,33 @@ struct ForcePoint {
     float strength;
 };
 
+struct WorldConfig {
+    float worldWidth = 20.0f;
+    float worldHeight = 10.0f;
+    float smoothingRadius = 0.8f;
+    float targetDensity = 32.0f;
+    float pressureMultiplier = 100.0f;
+    float delta = 0.0f;
+    float drag = 0.9999f;
+    float gravity = 9.8f;
+    float collisionDamping = 1.0f;
+};
+
 class World {
 public:
     static const int numParticle = 1000;
 
 private:
     const int particleRadius = 5;
-    const float gravity = 9.8F;
-    const float worldSize[2] = {20, 10};
-    const float collisionDamping = 1.0F;
-    const float smoothingRadius = 0.8F;
-    const float targetDensity = 32.0F;
-    const float pressureMultiplier = 100.0F;
-    const float delta = 0.0F;
-    const float drag = 0.9999F;
+
+    float gravity = 9.8f;
+    float worldSize[2] = {20.0f, 10.0f};
+    float collisionDamping = 1.0f;
+    float smoothingRadius = 0.8f;
+    float targetDensity = 32.0f;
+    float pressureMultiplier = 100.0f;
+    float delta = 0.0f;
+    float drag = 0.9999f;
 
     float pos[numParticle][2];
     float predpos[numParticle][2];
@@ -70,13 +83,20 @@ private:
     GridMap gridmap;
 
 public:
-    World();
+    World(const WorldConfig& config = WorldConfig());
 
     void setInteractionForce(float posX, float posY, float radius, float strength);
     void deleteInteractionForce();
 
     float getWorldWidth() const;
     float getWorldHeight() const;
+    float getSmoothingRadius() const { return smoothingRadius; }
+    float getGravity() const { return gravity; }
+    float getDrag() const { return drag; }
+    float getTargetDensity() const { return targetDensity; }
+    float getPressureMultiplier() const { return pressureMultiplier; }
+    float getDelta() const { return delta; }
+    float getCollisionDamping() const { return collisionDamping; }
 
     void update(float deltaTime);
     const float (*getPositions() const)[2] { return pos; }

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -27,3 +27,19 @@ def test_interaction_force_methods():
     w.set_interaction_force(1.0, 1.0, 2.0, 5.0)
     w.step(1.0 / 60.0)
     w.delete_interaction_force()
+
+
+def test_custom_parameters_affect_world_size():
+    w = _sph.PyWorld(width=5.0, height=3.0)
+    assert w.width() == 5.0
+    assert w.height() == 3.0
+
+
+def test_custom_physics_parameters():
+    w = _sph.PyWorld(gravity=20.0, smoothing_radius=1.2, drag=0.5)
+    assert np.isclose(w.gravity(), 20.0)
+    assert np.isclose(w.smoothing_radius(), 1.2)
+    assert np.isclose(w.drag(), 0.5)
+    # ensure stepping does not raise
+    w.step(1.0 / 60.0)
+


### PR DESCRIPTION
## Summary
- make `World` accept a `WorldConfig` for customizing world and fluid settings
- expose configuration options and getters in the Python bindings
- extend bindings tests with coverage for custom parameters

## Testing
- `PYTHONPATH=build pytest -q tests`

------
https://chatgpt.com/codex/tasks/task_e_685e074742f88324a044c79086ba679a