### PR TITLE
Optimize GridMap neighborhood query

### DIFF
--- a/src/sph/core/world.cpp
+++ b/src/sph/core/world.cpp
@@ -16,7 +16,7 @@ GridMap::GridMap(float width, float height, float radius)
     chunks.assign(numChunk, std::vector<int>());
 }
 
-std::vector<int> GridMap::getChunk(int chunkX, int chunkY) {
+const std::vector<int>& GridMap::getChunk(int chunkX, int chunkY) const {
     return chunks[chunkY * numChunkWidth + chunkX];
 }
 
@@ -48,7 +48,7 @@ std::vector<int> GridMap::findNeighborhood(float x, float y, float radius) {
         for (int y1 = minChunkY; y1 <= maxChunkY; ++y1) {
             if (x1 < 0 || x1 >= numChunkWidth) continue;
             if (y1 < 0 || y1 >= numChunkHeight) continue;
-            auto chunk = getChunk(x1, y1);
+            const auto& chunk = getChunk(x1, y1);
             out.insert(out.end(), chunk.begin(), chunk.end());
         }
     }

--- a/src/sph/core/world.h
+++ b/src/sph/core/world.h
@@ -28,7 +28,7 @@ private:
 
 public:
     GridMap(float width, float height, float radius);
-    std::vector<int> getChunk(int chunkX, int chunkY);
+    const std::vector<int>& getChunk(int chunkX, int chunkY) const;
     void registerTarget(int target, float x, float y);
     void unregisterAll();
     std::vector<int> findNeighborhood(float x, float y, float radius);


### PR DESCRIPTION
## Summary
- return `const` reference from `GridMap::getChunk`
- avoid vector copies in `findNeighborhood`

## Testing
- `cmake --build build`
- `ctest --test-dir build` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea7fc2f808324aba36daad786299d