### PR TITLE
Reuse CUDA buffers for kernel computation

### DIFF
--- a/src/sph/core/kernels_cuda.cu
+++ b/src/sph/core/kernels_cuda.cu
@@ -24,24 +24,17 @@ __global__ void calcSmoothingKernelKernel(const float* dist, float* out, float r
     }
 }
 
-void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n)
+void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n,
+                             float* d_in, float* d_out)
 {
-    float* d_in = nullptr;
-    float* d_out = nullptr;
-    CUDA_CHECK(cudaMalloc(&d_in, n * sizeof(float)));
-    CUDA_CHECK(cudaMalloc(&d_out, n * sizeof(float)));
     CUDA_CHECK(cudaMemcpy(d_in, dist, n * sizeof(float), cudaMemcpyHostToDevice));
 
     int threads = 256;
     int blocks = (n + threads - 1) / threads;
     calcSmoothingKernelKernel<<<blocks, threads>>>(d_in, d_out, radius, n);
     CUDA_KERNEL_CHECK();
-    CUDA_CHECK(cudaDeviceSynchronize());
 
     CUDA_CHECK(cudaMemcpy(out, d_out, n * sizeof(float), cudaMemcpyDeviceToHost));
-
-    CUDA_CHECK(cudaFree(d_in));
-    CUDA_CHECK(cudaFree(d_out));
 }
 
 } // namespace sph

--- a/src/sph/core/kernels_cuda.h
+++ b/src/sph/core/kernels_cuda.h
@@ -19,11 +19,13 @@ namespace sph {
 #ifdef __CUDACC__
 __global__ void calcSmoothingKernelKernel(const float* dist, float* out, float radius, int n);
 #endif
-void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n);
+void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n,
+                             float* d_in, float* d_out);
 
 #else // !USE_CUDA
 
-inline void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n)
+inline void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n,
+                                    float*, float*)
 {
     for (int i = 0; i < n; ++i) {
         out[i] = calcSmoothingKernel(dist[i], radius);

--- a/src/sph/core/world.h
+++ b/src/sph/core/world.h
@@ -81,9 +81,14 @@ private:
 
     ForcePoint forcePoint;
     GridMap gridmap;
+#ifdef USE_CUDA
+    float* d_dist_buffer = nullptr;
+    float* d_out_buffer = nullptr;
+#endif
 
 public:
     World(const WorldConfig& config = WorldConfig());
+    ~World();
 
     void setInteractionForce(float posX, float posY, float radius, float strength);
     void deleteInteractionForce();


### PR DESCRIPTION
## Summary
- modify `calcSmoothingKernelCUDA` to take preallocated device buffers
- allocate CUDA buffers once in `World` and reuse them
- update density calculation to use the persistent buffers
- extend test to manage CUDA buffers

## Testing
- `./setup.sh` *(fails: could not find pybind11 CMake package)*

------
https://chatgpt.com/codex/tasks/task_e_685eac0d4d888324baae6455806cc7d1