### PR TITLE
Update CI workflow for CUDA

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -54,15 +54,24 @@ jobs:
       run: |
         echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
 
+    - name: Install CUDA Toolkit
+      uses: Jimver/cuda-toolkit@v0.2.2
+      with:
+        cuda: "12.2.2"
+
+    - name: Install Python dependencies
+      run: python -m pip install pybind11 numpy
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
-        -S ${{ github.workspace }}
+          -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+          -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          -DUSE_CUDA=ON
+          -S ${{ github.workspace }}
 
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).


### PR DESCRIPTION
## Summary
- install CUDA toolkit in CI using Jimver/cuda-toolkit@v0.2.2
- install Python deps
- enable CUDA in CMake invocation

## Testing
- `cmake -DUSE_CUDA=OFF ..` *(fails: Could not find pybind11Config.cmake)*
- `ctest` *(fails: No test configuration file found)*


------
https://chatgpt.com/codex/tasks/task_e_685f318ca68c8324a52a70c95bfccefe