### PR TITLE
Split smoothing kernel into CPU and GPU paths

### DIFF
--- a/src/sph/core/kernels_cuda.cu
+++ b/src/sph/core/kernels_cuda.cu
@@ -24,17 +24,12 @@ __global__ void calcSmoothingKernelKernel(const float* dist, float* out, float r
     }
 }
 
-void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n,
-                             float* d_in, float* d_out)
+void calcSmoothingKernelGPU(const float* d_dist, float* d_out, float radius, int n)
 {
-    CUDA_CHECK(cudaMemcpy(d_in, dist, n * sizeof(float), cudaMemcpyHostToDevice));
-
     int threads = 256;
     int blocks = (n + threads - 1) / threads;
-    calcSmoothingKernelKernel<<<blocks, threads>>>(d_in, d_out, radius, n);
+    calcSmoothingKernelKernel<<<blocks, threads>>>(d_dist, d_out, radius, n);
     CUDA_KERNEL_CHECK();
-
-    CUDA_CHECK(cudaMemcpy(out, d_out, n * sizeof(float), cudaMemcpyDeviceToHost));
 }
 
 } // namespace sph

--- a/src/sph/core/kernels_cuda.h
+++ b/src/sph/core/kernels_cuda.h
@@ -19,20 +19,22 @@ namespace sph {
 #ifdef __CUDACC__
 __global__ void calcSmoothingKernelKernel(const float* dist, float* out, float radius, int n);
 #endif
-void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n,
-                             float* d_in, float* d_out);
 
-#else // !USE_CUDA
+// Calculate the kernel on the GPU. The input and output pointers must already
+// reside on the device; this function performs no memory copies.
+void calcSmoothingKernelGPU(const float* d_dist, float* d_out, float radius, int n);
 
-inline void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n,
-                                    float*, float*)
+#endif // USE_CUDA
+
+// Pure CPU implementation used when CUDA is unavailable or when running on the
+// host even in CUDA builds.
+inline void calcSmoothingKernelCPU(const float* dist, float* out, float radius, int n)
 {
     for (int i = 0; i < n; ++i) {
         out[i] = calcSmoothingKernel(dist[i], radius);
     }
 }
 
-#endif // USE_CUDA
 
 } // namespace sph
 

--- a/tests/test_kernel_compare.cpp
+++ b/tests/test_kernel_compare.cpp
@@ -20,11 +20,13 @@ int main() {
     float* d_out = nullptr;
     CUDA_CHECK(cudaMalloc(&d_in, n * sizeof(float)));
     CUDA_CHECK(cudaMalloc(&d_out, n * sizeof(float)));
-    sph::calcSmoothingKernelCUDA(distances.data(), gpu.data(), radius, n, d_in, d_out);
+    CUDA_CHECK(cudaMemcpy(d_in, distances.data(), n * sizeof(float), cudaMemcpyHostToDevice));
+    sph::calcSmoothingKernelGPU(d_in, d_out, radius, n);
+    CUDA_CHECK(cudaMemcpy(gpu.data(), d_out, n * sizeof(float), cudaMemcpyDeviceToHost));
     CUDA_CHECK(cudaFree(d_in));
     CUDA_CHECK(cudaFree(d_out));
 #else
-    sph::calcSmoothingKernelCUDA(distances.data(), gpu.data(), radius, n, nullptr, nullptr);
+    sph::calcSmoothingKernelCPU(distances.data(), gpu.data(), radius, n);
 #endif
     for (int i = 0; i < n; ++i) {
         assert(std::abs(cpu[i] - gpu[i]) < 1e-5f);


### PR DESCRIPTION
## Summary
- add separate CPU and GPU implementations for the smoothing kernel
- use explicit cudaMemcpy calls in `World::calcDensity`
- update kernel comparison test for the new API

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6861f85ce7d08324a00ccba96c95d840