### PR TITLE
Use structure-of-arrays layout

### DIFF
--- a/bindings/pybind_module.cpp
+++ b/bindings/pybind_module.cpp
@@ -24,14 +24,28 @@ public:
 
     py::array_t<float> get_positions() const {
         constexpr int N = sph::World::numParticle;
-        const float (*pos)[2] = world.getPositions();
-        return py::array_t<float>({N, 2}, &pos[0][0]);
+        auto arr = py::array_t<float>({N, 2});
+        auto buf = arr.mutable_unchecked<2>();
+        const auto& x = world.getPosX();
+        const auto& y = world.getPosY();
+        for (int i = 0; i < N; ++i) {
+            buf(i, 0) = x[i];
+            buf(i, 1) = y[i];
+        }
+        return arr;
     }
 
     py::array_t<float> get_velocities() const {
         constexpr int N = sph::World::numParticle;
-        const float (*vel)[2] = world.getVelocities();
-        return py::array_t<float>({N, 2}, &vel[0][0]);
+        auto arr = py::array_t<float>({N, 2});
+        auto buf = arr.mutable_unchecked<2>();
+        const auto& x = world.getVelX();
+        const auto& y = world.getVelY();
+        for (int i = 0; i < N; ++i) {
+            buf(i, 0) = x[i];
+            buf(i, 1) = y[i];
+        }
+        return arr;
     }
 
     float width() const { return world.getWorldWidth(); }

--- a/src/sph/core/world.h
+++ b/src/sph/core/world.h
@@ -16,11 +16,18 @@ namespace sph {
 
 float floatRand();
 #ifdef USE_CUDA
-void predictedPosCUDA(float* d_pos, float* d_vel, float* d_predpos,
+void predictedPosCUDA(float* d_posX, float* d_posY,
+                      float* d_velX, float* d_velY,
+                      float* d_predX, float* d_predY,
                       float gravity, float dt, int n);
-void updatePositionCUDA(float* d_pos, float* d_vel, float* d_pressure,
-                        float* d_interaction, float drag, float dt, int n);
-void fixPositionCUDA(float* d_pos, float* d_vel, float width, float height,
+void updatePositionCUDA(float* d_posX, float* d_posY,
+                        float* d_velX, float* d_velY,
+                        float* d_pressureX, float* d_pressureY,
+                        float* d_interactionX, float* d_interactionY,
+                        float drag, float dt, int n);
+void fixPositionCUDA(float* d_posX, float* d_posY,
+                     float* d_velX, float* d_velY,
+                     float width, float height,
                      float damping, int n);
 #endif
 
@@ -90,28 +97,28 @@ private:
     float delta = 0.0f;
     float drag = 0.9999f;
 
-    float pos[numParticle][2];
-    float predpos[numParticle][2];
-    float vel[numParticle][2];
-    float density[numParticle];
-    float pressureAccelerations[numParticle][2];
-    float interactionForce[numParticle][2];
-    int color[numParticle][3];
+    std::vector<float> posX, posY;
+    std::vector<float> predPosX, predPosY;
+    std::vector<float> velX, velY;
+    std::vector<float> density;
+    std::vector<float> pressureX, pressureY;
+    std::vector<float> interactionX, interactionY;
+    std::vector<int> colorR, colorG, colorB;
     std::vector<std::vector<int>> querysize;
     std::vector<int> iterator;
-    float mass[numParticle];
+    std::vector<float> mass;
 
     ForcePoint forcePoint;
     GridMap gridmap;
 #ifdef USE_CUDA
     float* d_dist_buffer = nullptr;
     float* d_out_buffer = nullptr;
-    float* d_pos = nullptr;
-    float* d_predpos = nullptr;
-    float* d_vel = nullptr;
+    float *d_posX = nullptr, *d_posY = nullptr;
+    float *d_predPosX = nullptr, *d_predPosY = nullptr;
+    float *d_velX = nullptr, *d_velY = nullptr;
     float* d_density = nullptr;
-    float* d_pressure = nullptr;
-    float* d_interaction = nullptr;
+    float *d_pressureX = nullptr, *d_pressureY = nullptr;
+    float *d_interactionX = nullptr, *d_interactionY = nullptr;
 #endif
 
 public:
@@ -135,8 +142,10 @@ public:
 
     void update(float deltaTime);
     void updateWithStats(float deltaTime, ProfileInfo& info);
-    const float (*getPositions() const)[2] { return pos; }
-    const float (*getVelocities() const)[2] { return vel; }
+    const std::vector<float>& getPosX() const { return posX; }
+    const std::vector<float>& getPosY() const { return posY; }
+    const std::vector<float>& getVelX() const { return velX; }
+    const std::vector<float>& getVelY() const { return velY; }
 
 private:
     void predictedPos(float deltaTime, ProfileInfo* info = nullptr);

--- a/src/sph/core/world_cuda.cu
+++ b/src/sph/core/world_cuda.cu
@@ -6,77 +6,96 @@
 
 namespace sph {
 
-__global__ void predictedPosKernel(float* pos, float* vel, float* predpos,
+__global__ void predictedPosKernel(float* posX, float* posY,
+                                   float* velX, float* velY,
+                                   float* predX, float* predY,
                                    float gravity, float dt, int n)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < n) {
-        vel[idx*2 + 1] += gravity * dt;
-        predpos[idx*2 + 0] = pos[idx*2 + 0] + vel[idx*2 + 0] * (1.0f/120.0f);
-        predpos[idx*2 + 1] = pos[idx*2 + 1] + vel[idx*2 + 1] * (1.0f/120.0f);
+        velY[idx] += gravity * dt;
+        predX[idx] = posX[idx] + velX[idx] * (1.0f/120.0f);
+        predY[idx] = posY[idx] + velY[idx] * (1.0f/120.0f);
     }
 }
 
-void predictedPosCUDA(float* d_pos, float* d_vel, float* d_predpos,
+void predictedPosCUDA(float* d_posX, float* d_posY,
+                      float* d_velX, float* d_velY,
+                      float* d_predX, float* d_predY,
                       float gravity, float dt, int n)
 {
     int threads = 256;
     int blocks = (n + threads - 1) / threads;
-    predictedPosKernel<<<blocks, threads>>>(d_pos, d_vel, d_predpos,
+    predictedPosKernel<<<blocks, threads>>>(d_posX, d_posY,
+                                            d_velX, d_velY,
+                                            d_predX, d_predY,
                                             gravity, dt, n);
     CUDA_KERNEL_CHECK();
 }
 
-__global__ void updatePositionKernel(float* pos, float* vel,
-                                     const float* pressure,
-                                     const float* interaction,
+__global__ void updatePositionKernel(float* posX, float* posY,
+                                     float* velX, float* velY,
+                                     const float* pressureX,
+                                     const float* pressureY,
+                                     const float* interactionX,
+                                     const float* interactionY,
                                      float drag, float dt, int n)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < n) {
-        vel[idx*2 + 0] += (pressure[idx*2 + 0] + interaction[idx*2 + 0]) * dt;
-        vel[idx*2 + 1] += (pressure[idx*2 + 1] + interaction[idx*2 + 1]) * dt;
-        pos[idx*2 + 0] += vel[idx*2 + 0] * dt;
-        pos[idx*2 + 1] += vel[idx*2 + 1] * dt;
-        vel[idx*2 + 0] *= drag;
-        vel[idx*2 + 1] *= drag;
+        velX[idx] += (pressureX[idx] + interactionX[idx]) * dt;
+        velY[idx] += (pressureY[idx] + interactionY[idx]) * dt;
+        posX[idx] += velX[idx] * dt;
+        posY[idx] += velY[idx] * dt;
+        velX[idx] *= drag;
+        velY[idx] *= drag;
     }
 }
 
-void updatePositionCUDA(float* d_pos, float* d_vel, float* d_pressure,
-                        float* d_interaction, float drag, float dt, int n)
+void updatePositionCUDA(float* d_posX, float* d_posY,
+                        float* d_velX, float* d_velY,
+                        float* d_pressureX, float* d_pressureY,
+                        float* d_interactionX, float* d_interactionY,
+                        float drag, float dt, int n)
 {
     int threads = 256;
     int blocks = (n + threads - 1) / threads;
-    updatePositionKernel<<<blocks, threads>>>(d_pos, d_vel,
-                                             d_pressure, d_interaction,
+    updatePositionKernel<<<blocks, threads>>>(d_posX, d_posY,
+                                             d_velX, d_velY,
+                                             d_pressureX, d_pressureY,
+                                             d_interactionX, d_interactionY,
                                              drag, dt, n);
     CUDA_KERNEL_CHECK();
 }
 
-__global__ void fixPositionKernel(float* pos, float* vel,
+__global__ void fixPositionKernel(float* posX, float* posY,
+                                  float* velX, float* velY,
                                   float width, float height,
                                   float damping, int n)
 {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < n) {
-        float x = pos[idx*2 + 0];
-        float y = pos[idx*2 + 1];
-        float vx = vel[idx*2 + 0];
-        float vy = vel[idx*2 + 1];
-        if (x < 0) { pos[idx*2 + 0] = 0; vel[idx*2 + 0] = -vx * damping; }
-        if (width < x) { pos[idx*2 + 0] = width; vel[idx*2 + 0] = -vx * damping; }
-        if (y < 0) { pos[idx*2 + 1] = 0; vel[idx*2 + 1] = -vy * damping; }
-        if (height < y) { pos[idx*2 + 1] = height; vel[idx*2 + 1] = -vy * damping; }
+        float x = posX[idx];
+        float y = posY[idx];
+        float vx = velX[idx];
+        float vy = velY[idx];
+        if (x < 0) { posX[idx] = 0; velX[idx] = -vx * damping; }
+        if (width < x) { posX[idx] = width; velX[idx] = -vx * damping; }
+        if (y < 0) { posY[idx] = 0; velY[idx] = -vy * damping; }
+        if (height < y) { posY[idx] = height; velY[idx] = -vy * damping; }
     }
 }
 
-void fixPositionCUDA(float* d_pos, float* d_vel, float width, float height,
+void fixPositionCUDA(float* d_posX, float* d_posY,
+                     float* d_velX, float* d_velY,
+                     float width, float height,
                      float damping, int n)
 {
     int threads = 256;
     int blocks = (n + threads - 1) / threads;
-    fixPositionKernel<<<blocks, threads>>>(d_pos, d_vel, width, height,
+    fixPositionKernel<<<blocks, threads>>>(d_posX, d_posY,
+                                          d_velX, d_velY,
+                                          width, height,
                                           damping, n);
     CUDA_KERNEL_CHECK();
 }


### PR DESCRIPTION
## Summary
- refactor World particle arrays to structure-of-arrays
- adjust CUDA kernels and world logic for new layout
- generate position/velocity matrices in bindings

## Testing
- `cmake .. -DUSE_CUDA=OFF -Dpybind11_DIR="$PYBIND11_DIR"`
- `cmake --build . -j4`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6861fa5caf908324907cae3ff5e71383