### PR TITLE
Improve test robustness

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,9 @@
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
+find_package(Python3 COMPONENTS Interpreter QUIET)
+find_package(pybind11 CONFIG QUIET)
+
+if(Python3_Interpreter_FOUND AND pybind11_FOUND)
+    find_package(Python3 COMPONENTS NumPy QUIET)
+endif()
 
 add_executable(test_calc test_calc.cpp)
 target_link_libraries(test_calc PRIVATE sph)
@@ -19,10 +24,14 @@ if(USE_CUDA AND SPH_ENABLE_HASH2D)
     add_test(NAME cpp_test_grid2d COMMAND test_grid2d)
 endif()
 
-add_test(NAME python_tests
-          COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}
-)
-set_tests_properties(python_tests PROPERTIES
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}"
-)
+if(Python3_Interpreter_FOUND AND pybind11_FOUND AND Python3_NumPy_FOUND)
+    add_test(NAME python_tests
+              COMMAND ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    set_tests_properties(python_tests PROPERTIES
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+        ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}"
+    )
+else()
+    message(WARNING "Python bindings tests skipped: missing Python interpreter, pybind11 or NumPy")
+endif()

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -1,4 +1,13 @@
-import numpy as np
+import pytest
+
+try:
+    import numpy as np
+except ImportError as exc:  # pragma: no cover - environment dependency
+    pytest.skip(
+        f"NumPy not available: {exc}. Skipping binding tests.",
+        allow_module_level=True,
+    )
+
 import _sph
 
 


### PR DESCRIPTION
## Summary
- skip bindings tests when NumPy isn't installed
- check for pybind11 and NumPy in tests/CMakeLists before adding Python tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named '_sph')*

------
https://chatgpt.com/codex/tasks/task_e_686204bed9a0832486116285583c8c3b