### PR TITLE
Apply timestep consistently for predicted positions

### DIFF
--- a/src/sph/core/world.cpp
+++ b/src/sph/core/world.cpp
@@ -299,8 +299,8 @@ void World::predictedPos(float deltaTime, ProfileInfo* info) {
     for (int i = 0; i < activeParticles; ++i) {
         velX[i] += 0.0f;
         velY[i] += mass[i] * gravity * deltaTime;
-        predPosX[i] = posX[i] + velX[i] * 1.0f / 120.0f;
-        predPosY[i] = posY[i] + velY[i] * 1.0f / 120.0f;
+        predPosX[i] = posX[i] + velX[i] * deltaTime;
+        predPosY[i] = posY[i] + velY[i] * deltaTime;
     }
 #endif
 }

--- a/src/sph/core/world_cuda.cu
+++ b/src/sph/core/world_cuda.cu
@@ -14,8 +14,8 @@ __global__ void predictedPosKernel(float* posX, float* posY,
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx < n) {
         velY[idx] += gravity * dt;
-        predX[idx] = posX[idx] + velX[idx] * (1.0f/120.0f);
-        predY[idx] = posY[idx] + velY[idx] * (1.0f/120.0f);
+        predX[idx] = posX[idx] + velX[idx] * dt;
+        predY[idx] = posY[idx] + velY[idx] * dt;
     }
 }
 


### PR DESCRIPTION
## Summary
- use the provided timestep when updating predicted positions
- mirror this change in the CUDA kernel

## Testing
- `./setup.sh`
- `PYTHONPATH=build pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862052d59f883249e797670a827ac41