### PR TITLE
Add GPU spatial hash doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SPH
 
+For details on optional CUDA neighbour-search support see [docs/GPU_Spatial_Hash_2D.md](docs/GPU_Spatial_Hash_2D.md).
+
 This repository contains a simple Smoothed Particle Hydrodynamics (SPH) simulation.
 
 ## Build instructions

--- a/docs/GPU_Spatial_Hash_2D.md
+++ b/docs/GPU_Spatial_Hash_2D.md
@@ -1,0 +1,42 @@
+# GPU Spatial Hash Neighbour Search (2-D)
+
+This document outlines how the optional CUDA implementation integrates
+with the rest of the repository. The architecture follows a clean
+separation of domain logic and GPU infrastructure.
+
+## Structure
+
+- **Domain layer (`src/sph/core`)** – physics, data structures and CPU fallback.
+- **Infrastructure layer (`src/sph/gpu`)** – CUDA kernels for hashing and neighbour search.
+- **Interface layer (`bindings`)** – Python bindings and example applications.
+
+The CUDA path requires devices with compute capability 8.0 or higher and
+uses features introduced in newer architectures. NVIDIA's programming
+guide states that operations such as warp reductions are supported only
+on devices of compute capability 8.0 and above【86cec1†L3-L21】.
+Cluster-wide synchronization is guaranteed on compute capability 9.0
+GPUs, where thread blocks share distributed memory【abb017†L3-L11】.
+
+## Build Option
+
+Enable GPU support when configuring CMake:
+
+```console
+cmake -DUSE_CUDA=ON ..
+```
+
+When `SPH_ENABLE_HASH2D` is defined, the CUDA sources in
+`src/sph/gpu` are compiled and the `World` class dispatches to the
+GPU neighbour search.
+
+## Workflow
+
+1. The host collects particle buffers and launches
+   `computeHashKernel` and `findCellStartKernel`.
+2. Sorted indices are fed to `neighbourSearchKernel` which runs in a
+   persistent grid.
+3. Subsequent density and force kernels reuse the neighbour lists.
+
+The default build targets compute capability 9.0 (Hopper) but can run
+on any GPU of capability 8.0 or newer.
+


### PR DESCRIPTION
## Summary
- document CUDA 2-D spatial hash neighbor search
- reference how to enable the optional GPU path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named '_sph')*

------
https://chatgpt.com/codex/tasks/task_e_6864b5bba3b483249dfc0819930565ac