### PR TITLE
Optimize CUDA kernel setup

### DIFF
--- a/src/sph/core/kernels_cuda.cu
+++ b/src/sph/core/kernels_cuda.cu
@@ -3,11 +3,29 @@
 #ifdef USE_CUDA
 
 #include <cmath>          // 必須
+#include <cstdlib>
 #ifndef M_PI              // まだ無ければ自前で定義
 #define M_PI 3.14159265358979323846
 #endif
 
 namespace sph {
+
+namespace {
+    // Cached device buffers and CUDA availability flag
+    bool             initialized   = false;
+    bool             gpu_available = false;
+    float*           d_in          = nullptr;
+    float*           d_out         = nullptr;
+    int              buffer_size   = 0;
+
+    void freeBuffers() {
+        if (d_in)  cudaFree(d_in);
+        if (d_out) cudaFree(d_out);
+        d_in  = nullptr;
+        d_out = nullptr;
+        buffer_size = 0;
+    }
+}
 
 __global__ void calcSmoothingKernelKernel(const float* dist, float* out, float radius, int n)
 {
@@ -26,33 +44,44 @@ __global__ void calcSmoothingKernelKernel(const float* dist, float* out, float r
 
 void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n)
 {
-    int deviceCount = 0;
-    cudaError_t status = cudaGetDeviceCount(&deviceCount);
-    if (status != cudaSuccess || deviceCount == 0) {
-        // Fallback to CPU implementation when CUDA is not available
+    if (!initialized) {
+        int deviceCount = 0;
+        cudaError_t st = cudaGetDeviceCount(&deviceCount);
+        gpu_available = (st == cudaSuccess && deviceCount > 0);
+        initialized = true;
+        if (gpu_available) std::atexit(freeBuffers);
+    }
+
+    if (!gpu_available) {
         for (int i = 0; i < n; ++i) {
             out[i] = calcSmoothingKernel(dist[i], radius);
         }
         return;
     }
 
-    float* d_in = nullptr;
-    float* d_out = nullptr;
-    status = cudaMalloc(&d_in, n * sizeof(float));
-    if (status != cudaSuccess) {
-        for (int i = 0; i < n; ++i) out[i] = calcSmoothingKernel(dist[i], radius);
-        return;
+    if (buffer_size != n) {
+        freeBuffers();
+        cudaError_t st1 = cudaMalloc(&d_in, n * sizeof(float));
+        if (st1 != cudaSuccess) {
+            gpu_available = false;
+            for (int i = 0; i < n; ++i) out[i] = calcSmoothingKernel(dist[i], radius);
+            return;
+        }
+        st1 = cudaMalloc(&d_out, n * sizeof(float));
+        if (st1 != cudaSuccess) {
+            cudaFree(d_in);
+            d_in = nullptr;
+            gpu_available = false;
+            for (int i = 0; i < n; ++i) out[i] = calcSmoothingKernel(dist[i], radius);
+            return;
+        }
+        buffer_size = n;
     }
-    status = cudaMalloc(&d_out, n * sizeof(float));
+
+    cudaError_t status = cudaMemcpy(d_in, dist, n * sizeof(float), cudaMemcpyHostToDevice);
     if (status != cudaSuccess) {
-        cudaFree(d_in);
-        for (int i = 0; i < n; ++i) out[i] = calcSmoothingKernel(dist[i], radius);
-        return;
-    }
-    status = cudaMemcpy(d_in, dist, n * sizeof(float), cudaMemcpyHostToDevice);
-    if (status != cudaSuccess) {
-        cudaFree(d_in);
-        cudaFree(d_out);
+        freeBuffers();
+        gpu_available = false;
         for (int i = 0; i < n; ++i) out[i] = calcSmoothingKernel(dist[i], radius);
         return;
     }
@@ -62,29 +91,26 @@ void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n)
     calcSmoothingKernelKernel<<<blocks, threads>>>(d_in, d_out, radius, n);
     status = cudaGetLastError();
     if (status != cudaSuccess) {
-        cudaFree(d_in);
-        cudaFree(d_out);
+        freeBuffers();
+        gpu_available = false;
         for (int i = 0; i < n; ++i) out[i] = calcSmoothingKernel(dist[i], radius);
         return;
     }
     status = cudaDeviceSynchronize();
     if (status != cudaSuccess) {
-        cudaFree(d_in);
-        cudaFree(d_out);
+        freeBuffers();
+        gpu_available = false;
         for (int i = 0; i < n; ++i) out[i] = calcSmoothingKernel(dist[i], radius);
         return;
     }
 
     status = cudaMemcpy(out, d_out, n * sizeof(float), cudaMemcpyDeviceToHost);
     if (status != cudaSuccess) {
-        cudaFree(d_in);
-        cudaFree(d_out);
+        freeBuffers();
+        gpu_available = false;
         for (int i = 0; i < n; ++i) out[i] = calcSmoothingKernel(dist[i], radius);
         return;
     }
-
-    cudaFree(d_in);
-    cudaFree(d_out);
 }
 
 } // namespace sph


### PR DESCRIPTION
## Summary
- cache CUDA buffers in `calcSmoothingKernelCUDA`
- only check device count once
- reuse buffers across calls and free them on exit

## Testing
- `PYTHONPATH=build pytest -q` with CUDA on and off
- `cmake --build .` with CUDA off (hash grid disabled)
- `cmake --build .` with CUDA on

------
https://chatgpt.com/codex/tasks/task_e_686d5ae3cf208324b38522c14611af38