### PR TITLE
Expose C++ neighbour query

### DIFF
--- a/bindings/pybind_module.cpp
+++ b/bindings/pybind_module.cpp
@@ -1,5 +1,6 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/stl.h>
 #include "sph/core/world.h"
 
 namespace py = pybind11;
@@ -59,6 +60,10 @@ public:
 
     void delete_interaction_force() { world.deleteInteractionForce(); }
 
+    std::vector<int> query_neighbors(float x, float y) const {
+        return world.queryNeighbors(x, y);
+    }
+
 private:
     sph::World world;
     bool use_gpu = false;
@@ -105,5 +110,10 @@ PYBIND11_MODULE(_sph, m) {
             py::arg("y"),
             py::arg("radius"),
             py::arg("strength"))
+        .def(
+            "query_neighbors",
+            &PyWorld::query_neighbors,
+            py::arg("x"),
+            py::arg("y"))
         .def("delete_interaction_force", &PyWorld::delete_interaction_force);
 }

--- a/examples/run_gui.py
+++ b/examples/run_gui.py
@@ -58,13 +58,8 @@ def main():
             step_once = False
         positions = world.get_positions()
         if query_pos is not None:
-            # determine which particles are within the neighbour search radius
-            neighbour_indices = [
-                i
-                for i, (px, py) in enumerate(positions)
-                if (px - query_pos[0]) ** 2 + (py - query_pos[1]) ** 2
-                <= world.smoothing_radius() ** 2
-            ]
+            # query neighbours using the C++ implementation
+            neighbour_indices = list(world.query_neighbors(query_pos[0], query_pos[1]))
         proc_time = (time.perf_counter() - start_time) * 1000.0
 
         screen.fill((0, 0, 0))

--- a/src/sph/core/world.cpp
+++ b/src/sph/core/world.cpp
@@ -16,7 +16,7 @@ GridMap::GridMap(float width, float height, float radius)
     chunks.assign(numChunk, std::vector<int>());
 }
 
-std::vector<int> GridMap::getChunk(int chunkX, int chunkY) {
+std::vector<int> GridMap::getChunk(int chunkX, int chunkY) const {
     return chunks[chunkY * numChunkWidth + chunkX];
 }
 
@@ -34,7 +34,7 @@ void GridMap::unregisterAll() {
     }
 }
 
-std::vector<int> GridMap::findNeighborhood(float x, float y, float radius) {
+std::vector<int> GridMap::findNeighborhood(float x, float y, float radius) const {
     std::vector<int> out;
     int centerChunkX = static_cast<int>(x / chunkRange);
     int centerChunkY = static_cast<int>(y / chunkRange);
@@ -282,6 +282,21 @@ void World::calcInteractionForce(float outForce[], int particleIndex) const {
     float velY = vel[particleIndex][1];
     outForce[0] = (dirToForcePosX * p.strength - velX) * centreT;
     outForce[1] = (dirToForcePosY * p.strength - velY) * centreT;
+}
+
+std::vector<int> World::queryNeighbors(float x, float y) const {
+    auto candidates = gridmap.findNeighborhood(x, y, smoothingRadius);
+    std::vector<int> result;
+    result.reserve(candidates.size());
+    float r2 = smoothingRadius * smoothingRadius;
+    for (int idx : candidates) {
+        float dx = pos[idx][0] - x;
+        float dy = pos[idx][1] - y;
+        if (dx * dx + dy * dy <= r2) {
+            result.push_back(idx);
+        }
+    }
+    return result;
 }
 
 } // namespace sph

--- a/src/sph/core/world.h
+++ b/src/sph/core/world.h
@@ -29,10 +29,10 @@ private:
 
 public:
     GridMap(float width, float height, float radius);
-    std::vector<int> getChunk(int chunkX, int chunkY);
+    std::vector<int> getChunk(int chunkX, int chunkY) const;
     void registerTarget(int target, float x, float y);
     void unregisterAll();
-    std::vector<int> findNeighborhood(float x, float y, float radius);
+    std::vector<int> findNeighborhood(float x, float y, float radius) const;
 };
 
 struct ForcePoint {
@@ -106,6 +106,9 @@ public:
     size_t getNumParticles() const { return numParticle; }
     const std::vector<std::array<float,2>>& getPositions() const { return pos; }
     const std::vector<std::array<float,2>>& getVelocities() const { return vel; }
+
+    // query neighbours around an arbitrary point
+    std::vector<int> queryNeighbors(float x, float y) const;
 
 private:
     void predictedPos(float deltaTime);

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -29,6 +29,16 @@ def test_interaction_force_methods():
     w.delete_interaction_force()
 
 
+def test_query_neighbors_returns_indices():
+    w = _sph.PyWorld()
+    w.step(1.0 / 60.0)
+    pos = w.get_positions()
+    x, y = pos[0]
+    neighbours = w.query_neighbors(float(x), float(y))
+    assert isinstance(neighbours, list)
+    assert 0 in neighbours
+
+
 def test_custom_parameters_affect_world_size():
     w = _sph.PyWorld(width=5.0, height=3.0)
     assert w.width() == 5.0


### PR DESCRIPTION
## Summary
- expose a C++ `queryNeighbors` method through pybind11
- use the new method in the pygame demo
- test the new API

## Testing
- `cmake .. -DUSE_CUDA=OFF -Dpybind11_DIR=$(python3 -c 'import pybind11;print(pybind11.get_cmake_dir())')`
- `cmake --build . --target _sph`
- `PYTHONPATH=build python3 -m pytest -q tests/test_bindings.py`

------
https://chatgpt.com/codex/tasks/task_e_6873735f5d048324ad1e47973ce13410