### PR TITLE
Add spatial hash debug query

### DIFF
--- a/bindings/pybind_module.cpp
+++ b/bindings/pybind_module.cpp
@@ -64,6 +64,10 @@ public:
         return world.queryNeighbors(x, y);
     }
 
+    std::vector<int> query_spatial_hash(float x, float y) const {
+        return world.querySpatialHash(x, y);
+    }
+
 private:
     sph::World world;
     bool use_gpu = false;
@@ -113,6 +117,11 @@ PYBIND11_MODULE(_sph, m) {
         .def(
             "query_neighbors",
             &PyWorld::query_neighbors,
+            py::arg("x"),
+            py::arg("y"))
+        .def(
+            "query_spatial_hash",
+            &PyWorld::query_spatial_hash,
             py::arg("x"),
             py::arg("y"))
         .def("delete_interaction_force", &PyWorld::delete_interaction_force);

--- a/examples/run_gui.py
+++ b/examples/run_gui.py
@@ -24,6 +24,7 @@ def main():
     # store current query position for neighbour highlight
     query_pos = None
     neighbour_indices = []
+    hash_indices = []
 
     while running:
         start_time = time.perf_counter()
@@ -52,6 +53,7 @@ def main():
             world.delete_interaction_force()
             query_pos = None
             neighbour_indices = []
+            hash_indices = []
 
         if not paused or step_once:
             world.step(dt)
@@ -60,11 +62,17 @@ def main():
         if query_pos is not None:
             # query neighbours using the C++ implementation
             neighbour_indices = list(world.query_neighbors(query_pos[0], query_pos[1]))
+            hash_indices = list(world.query_spatial_hash(query_pos[0], query_pos[1]))
         proc_time = (time.perf_counter() - start_time) * 1000.0
 
         screen.fill((0, 0, 0))
         for idx, (x, y) in enumerate(positions):
-            color = (0, 255, 0) if idx in neighbour_indices else (255, 255, 255)
+            if idx in neighbour_indices:
+                color = (0, 255, 0)
+            elif idx in hash_indices:
+                color = (0, 0, 255)
+            else:
+                color = (255, 255, 255)
             pygame.draw.circle(
                 screen,
                 color,

--- a/src/sph/core/world.cpp
+++ b/src/sph/core/world.cpp
@@ -299,5 +299,9 @@ std::vector<int> World::queryNeighbors(float x, float y) const {
     return result;
 }
 
+std::vector<int> World::querySpatialHash(float x, float y) const {
+    return gridmap.findNeighborhood(x, y, smoothingRadius);
+}
+
 } // namespace sph
 

--- a/src/sph/core/world.h
+++ b/src/sph/core/world.h
@@ -109,6 +109,8 @@ public:
 
     // query neighbours around an arbitrary point
     std::vector<int> queryNeighbors(float x, float y) const;
+    // return indices from spatial hash before distance filtering
+    std::vector<int> querySpatialHash(float x, float y) const;
 
 private:
     void predictedPos(float deltaTime);

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -39,6 +39,16 @@ def test_query_neighbors_returns_indices():
     assert 0 in neighbours
 
 
+def test_query_spatial_hash_returns_candidates():
+    w = _sph.PyWorld()
+    w.step(1.0 / 60.0)
+    pos = w.get_positions()
+    x, y = pos[0]
+    candidates = w.query_spatial_hash(float(x), float(y))
+    assert isinstance(candidates, list)
+    assert 0 in candidates
+
+
 def test_custom_parameters_affect_world_size():
     w = _sph.PyWorld(width=5.0, height=3.0)
     assert w.width() == 5.0


### PR DESCRIPTION
## Summary
- expose spatial hash candidate query in `World`
- bind new method through PyBind11
- colorize hashing candidates in run_gui demo
- add regression test for the new Python binding

## Testing
- `./setup.sh`
- `PYTHONPATH=build pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687377445f34832486e14ae430bbdea9