### PR TITLE
Add benchmark documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,14 @@ PYTHONPATH=build/bindings python examples/plot_snapshot.py
 
 Running the script produces an image named `snapshot.png` in the
 `examples` directory.
+
+## Benchmark
+
+A benchmark script reports the time for a single simulation step while
+increasing the particle count:
+
+```console
+PYTHONPATH=build python bench/run_dambreak.py
+```
+
+See [docs/benchmarks.md](docs/benchmarks.md) for more details.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,9 @@
+# Benchmarking the SPH Simulation
+
+This repository contains a simple benchmark that measures the time for a single simulation step while scaling the particle count. After building the Python extension, run the following command from the repository root:
+
+```console
+PYTHONPATH=build python bench/run_dambreak.py
+```
+
+The script iterates over increasing particle counts and prints the step time in milliseconds.

--- a/docs/build.md
+++ b/docs/build.md
@@ -36,6 +36,9 @@ The benchmark script steps the simulation for increasing particle counts:
 PYTHONPATH=build python bench/run_dambreak.py
 ```
 
+The output lists the step time in milliseconds. See
+[benchmarks.md](benchmarks.md) for further details.
+
 ## Python usage
 Run the Pygame example after building the extension:
 ```console


### PR DESCRIPTION
## Summary
- document benchmark script in README
- crosslink in build instructions
- add a new `docs/benchmarks.md` file describing benchmark usage

## Testing
- `./setup.sh`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6873967404448324b43ca4263e1c47ab