### PR TITLE
Fix README path for snapshot script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ After building the Python extension you can generate a scatter plot of the
 particle positions with colors representing their speed:
 
 ```console
-PYTHONPATH=build/bindings python examples/plot_snapshot.py
+PYTHONPATH=build python examples/plot_snapshot.py
 ```
 
 Running the script produces an image named `snapshot.png` in the


### PR DESCRIPTION
## Summary
- correct the command for visualizing particle velocities in README

## Testing
- `cmake -DUSE_CUDA=OFF -Dpybind11_DIR=$(python3 -m pybind11 --cmakedir) ..`
- `cmake --build . --target _sph`
- `cmake --build . --target test_calc test_kernel_compare`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68743fed98208324a695b4ce9ee82aa0