### PR TITLE
Update CUDA arch for RTX 4090

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,10 @@ if(USE_CUDA)
     endif()
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)  # LTOは nvcc が苦手なのでOFF
 endif()
-set(CMAKE_CUDA_ARCHITECTURES 90)
+# Target Ada Lovelace GPUs such as the RTX 4090 while still supporting
+# other compute capability 8.x devices. The architectures are listed in
+# ascending order so CMake generates code for each supported target.
+set(CMAKE_CUDA_ARCHITECTURES 80 86 89)
 
 add_library(sph_gpu STATIC
     src/sph/gpu/hash_grid_2d.cu

--- a/docs/GPU_Spatial_Hash_2D.md
+++ b/docs/GPU_Spatial_Hash_2D.md
@@ -37,8 +37,8 @@ GPU neighbour search.
    persistent grid.
 3. Subsequent density and force kernels reuse the neighbour lists.
 
-The CMake configuration sets `CMAKE_CUDA_ARCHITECTURES=90` so the build
-targets compute capability&nbsp;9.0 (Hopper). Systems with compute
-capability&nbsp;8.x can still run the code, but `CMAKE_CUDA_ARCHITECTURES`
-must be adjusted to match the hardware before configuring the project.
+The CMake configuration sets `CMAKE_CUDA_ARCHITECTURES=80 86 89` so the build
+targets compute capability&nbsp;8.x devices, including Ada Lovelace GPUs such as
+the RTX&nbsp;4090. Systems with different hardware can adjust
+`CMAKE_CUDA_ARCHITECTURES` accordingly before configuring the project.
 


### PR DESCRIPTION
## Summary
- target Ada GPUs such as RTX 4090 by setting `CMAKE_CUDA_ARCHITECTURES` to `80 86 89`
- mention new default architecture list in GPU spatial hashing doc

## Testing
- `cmake .. -DUSE_CUDA=ON -DSPH_ENABLE_HASH2D=ON -Dpybind11_DIR=$(python3 -m pybind11 --cmakedir)`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6874440f6238832494db4dd825e93987