### PR TITLE
Enable optional CUDA build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,14 @@
 cmake_minimum_required(VERSION 3.27)
-project(SPH LANGUAGES CXX CUDA)
+project(SPH LANGUAGES CXX)
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(USE_CUDA "Build with CUDA support" ON)
+if(USE_CUDA)
+    enable_language(CUDA)
+endif()
 option(SPH_ENABLE_HASH2D "Enable GPU 2-D spatial hashing" ${USE_CUDA})
 option(DEBUG_GPU "Enable additional CUDA checks" OFF)
 
@@ -21,18 +24,20 @@ if(USE_CUDA)
     endif()
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)  # LTOは nvcc が苦手なのでOFF
 endif()
-# Target Ada Lovelace GPUs such as the RTX 4090 while still supporting
-# other compute capability 8.x devices. The architectures are listed in
-# ascending order so CMake generates code for each supported target.
-set(CMAKE_CUDA_ARCHITECTURES 80 86 89)
+if(USE_CUDA)
+    # Target Ada Lovelace GPUs such as the RTX 4090 while still supporting
+    # other compute capability 8.x devices. The architectures are listed in
+    # ascending order so CMake generates code for each supported target.
+    set(CMAKE_CUDA_ARCHITECTURES 80 86 89)
 
-add_library(sph_gpu STATIC
-    src/sph/gpu/hash_grid_2d.cu
-    src/sph/gpu/neighbor_search_2d.cu)
+    add_library(sph_gpu STATIC
+        src/sph/gpu/hash_grid_2d.cu
+        src/sph/gpu/neighbor_search_2d.cu)
 
-target_link_libraries(sph_gpu PRIVATE cudadevrt)
-target_include_directories(sph_gpu PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
+    target_link_libraries(sph_gpu PRIVATE cudadevrt)
+    target_include_directories(sph_gpu PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
+endif()
 
 
 find_package(pybind11 CONFIG REQUIRED)

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,7 @@ set -e
 python3 -m pip install --user pybind11
 
 # Create build directory and build the Python extension
+export CMAKE_PREFIX_PATH="$(python3 -m pybind11 --cmakedir):${CMAKE_PREFIX_PATH}"
 mkdir -p build
 cd build
 cmake -DUSE_CUDA=OFF ..   # set to ON when the CUDA toolkit is available


### PR DESCRIPTION
## Summary
- make CUDA optional in `CMakeLists.txt`
- limit CUDA targets and library creation to `USE_CUDA` builds
- export pybind11 CMake path in `setup.sh`

## Testing
- `./setup.sh`
- `cmake --build .` and `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687448542f908324b20985c76bbc50dc