### PR TITLE
Add zero-size CUDA kernel test

### DIFF
--- a/tests/test_kernel_compare.cpp
+++ b/tests/test_kernel_compare.cpp
@@ -19,5 +19,10 @@ int main() {
     for (int i = 0; i < n; ++i) {
         assert(std::abs(cpu[i] - gpu[i]) < 1e-5f);
     }
+
+    // Ensure calling the CUDA kernel with zero length does not crash
+    std::vector<float> dummy_in(1), dummy_out(1);
+    sph::calcSmoothingKernelCUDA(dummy_in.data(), dummy_out.data(), radius, 0);
+
     return 0;
 }


### PR DESCRIPTION
## Summary
- verify CUDA smoothing kernel call with `n=0`

## Testing
- `cmake -S . -B build -DUSE_CUDA=ON`
- `cmake --build build`
- `cd build && ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6874485136488324bc96950dbe7817ed