### PR TITLE
Add early return in CUDA kernel and rebuild

### DIFF
--- a/src/sph/core/kernels_cuda.cu
+++ b/src/sph/core/kernels_cuda.cu
@@ -50,6 +50,9 @@ __global__ void calcSmoothingKernelKernel(const float* dist, float* out, float r
 
 void calcSmoothingKernelCUDA(const float* dist, float* out, float radius, int n)
 {
+    if (n <= 0) {
+        return;
+    }
     if (!initialized) {
         int deviceCount = 0;
         CUDA_TRY(cudaGetDeviceCount(&deviceCount));


### PR DESCRIPTION
## Summary
- handle `n <= 0` in `calcSmoothingKernelCUDA`
- built with CUDA and ran the demo to ensure it starts correctly

## Testing
- `bash setup.sh` (installs dependencies and initial CPU build)
- `cmake -DUSE_CUDA=ON ..`
- `cmake --build . --target _sph`
- `PYTHONPATH=. SDL_VIDEODRIVER=dummy python ../examples/run_gui.py` *(interrupted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_6874484fafa88324882ef4c7fe3d4770