### PR TITLE
Integrate CUDA hash grid

### DIFF
--- a/src/sph/core/world.h
+++ b/src/sph/core/world.h
@@ -12,6 +12,10 @@
 
 #include "kernels.h"
 #include "kernels_cuda.h"
+#ifdef SPH_ENABLE_HASH2D
+#include "sph/gpu/hash_grid_2d.hpp"
+#include <cuda_runtime.h>
+#endif
 
 namespace sph {
 
@@ -84,9 +88,18 @@ private:
 
     ForcePoint forcePoint;
     GridMap gridmap;
+#ifdef SPH_ENABLE_HASH2D
+    HashGrid2D grid;
+    uint32_t* d_neighbors = nullptr;
+    uint32_t* d_counts    = nullptr;
+    bool device_allocated = false;
+#endif
 
 public:
     World(const WorldConfig& config = WorldConfig());
+#ifdef SPH_ENABLE_HASH2D
+    ~World();
+#endif
 
     void setInteractionForce(float posX, float posY, float radius, float strength);
     void deleteInteractionForce();
@@ -125,6 +138,10 @@ private:
     float calcSharedPressure(float densityLeft, float densityRight) const;
     float convertDensityToPressure(float density) const;
     void calcInteractionForce(float outInteractionForce[], int particleIndex) const;
+#ifdef SPH_ENABLE_HASH2D
+    void allocateDeviceBuffers();
+    void freeDeviceBuffers();
+#endif
 };
 
 } // namespace sph


### PR DESCRIPTION
## Summary
- add optional CUDA hash grid members to `World`
- implement GPU neighbour search in `stepGPU`
- manage CUDA buffers when hashing is enabled

## Testing
- `cmake .. -DUSE_CUDA=OFF`
- `cmake --build .`
- `ctest --output-on-failure`
- *(CUDA build failed: `/usr/bin/ld: cannot find -lcuda_runtime`)*

------
https://chatgpt.com/codex/tasks/task_e_68746c6f70e88324b111136a168917d4