### PR TITLE
Fix destructor definition for World

### DIFF
--- a/src/sph/core/world.cpp
+++ b/src/sph/core/world.cpp
@@ -358,9 +358,13 @@ std::vector<int> World::querySpatialHash(float x, float y) const {
     return gridmap.findNeighborhood(x, y, smoothingRadius);
 }
 
+World::~World() {
 #ifdef SPH_ENABLE_HASH2D
-World::~World() { freeDeviceBuffers(); }
+    freeDeviceBuffers();
+#endif
+}
 
+#ifdef SPH_ENABLE_HASH2D
 void World::allocateDeviceBuffers() {
     if (device_allocated) return;
     uint32_t N = static_cast<uint32_t>(numParticle);

--- a/src/sph/core/world.h
+++ b/src/sph/core/world.h
@@ -97,9 +97,7 @@ private:
 
 public:
     World(const WorldConfig& config = WorldConfig());
-#ifdef SPH_ENABLE_HASH2D
     ~World();
-#endif
 
     void setInteractionForce(float posX, float posY, float radius, float strength);
     void deleteInteractionForce();


### PR DESCRIPTION
## Summary
- remove preprocessor guard around `World` destructor
- make destructor always available with conditional GPU cleanup
- update build outputs

## Testing
- `./setup.sh`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6874743846d48324a2e71f2dd9334582